### PR TITLE
correcte scale-factors and mt_tot

### DIFF
--- a/HTTAnalysis/HTTSynchNTuple.h
+++ b/HTTAnalysis/HTTSynchNTuple.h
@@ -92,7 +92,8 @@ class HTTSynchNTuple: public Analyzer{
   HTTParticle leg1, leg2;
 
   ///Histograms with lepton corrections
-  TH2F *h2DMuonIdIsoCorrections, *h2DMuonTrgCorrections;
+  TH2F *h2DMuonIdCorrections;
+  TH3F *h3DMuonIsoCorrections, *h3DMuonTrgCorrections;
   TH1F *h1DMuonTrkCorrections;
   TH3F *h3DTauCorrections;
   TH2F *h2DTauTrgGenuineCorrections, *h2DTauTrgFakeCorrections;


### PR DESCRIPTION
Jak w tytule: 
* poprawione wagi /scale-factors: odpowienie inputy, odpowiednie mapowanie na histogramy => dobra zgodnosc z innymi grupami
* poprawiony bug w definicji mt_tot => dobra zgodnosc z innymi grupami (modulo male roznice w Met)