### PR TITLE
Nowe kategorie: btag/no-btag dla MSSM i inclusive dla ogolnej kontroli

### DIFF
--- a/HTTAnalysis/ChannelSpecifics.cc
+++ b/HTTAnalysis/ChannelSpecifics.cc
@@ -76,10 +76,10 @@ void ChannelSpecifics::defineCategories(){
 	inclusive = new HTTAnalysis::eventCategory("inclusive", categoryRejester);
         antiIso_inclusive = new HTTAnalysis::eventCategory("antiIso_inclusive", categoryRejester);
 
-	bjet = new HTTAnalysis::eventCategory("bjet", categoryRejester);
-	nobjet = new HTTAnalysis::eventCategory("nobjet", categoryRejester);
-        antiIso_bjet = new HTTAnalysis::eventCategory("antiIso_bjet", categoryRejester);
-        antiIso_nobjet = new HTTAnalysis::eventCategory("antiIso_nobjet", categoryRejester);
+	btag = new HTTAnalysis::eventCategory("btag", categoryRejester);
+	nobtag = new HTTAnalysis::eventCategory("nobtag", categoryRejester);
+        antiIso_btag = new HTTAnalysis::eventCategory("antiIso_btag", categoryRejester);
+        antiIso_nobtag = new HTTAnalysis::eventCategory("antiIso_nobtag", categoryRejester);
 
 }
 /////////////////////////////////////////////////////////////////
@@ -248,7 +248,9 @@ float ChannelSpecifics::getLeptonCorrection(float eta, float pt, float iso,
 }
 /////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////
-bool ChannelSpecifics::promoteBJet(const HTTParticle &jet){
+bool ChannelSpecifics::promoteBJet(const HTTParticle &jet,
+				   const HTTAnalysis::sysEffects & aSystEffect,
+				   std::string correctionType){
   //MB: https://twiki.cern.ch/twiki/bin/view/CMS/BTagCalibration#Standalone
   bool decision = false;
 
@@ -262,10 +264,10 @@ bool ChannelSpecifics::promoteBJet(const HTTParticle &jet){
   else //light quark, gluon or undefined
     jetFlavour = BTagEntry::FLAV_UDSG;
   // Note: this is for b jets, for c jets (light jets) use FLAV_C (FLAV_UDSG)
-  double btag_SF = reader->eval_auto_bounds("central",
+  double btag_SF = reader->eval_auto_bounds(correctionType,//"central","up","down"
 					    jetFlavour,
-					    jet.getP4().Eta(),
-					    jet.getP4().Pt()
+					    jet.getP4(aSystEffect).Eta(),
+					    jet.getP4(aSystEffect).Pt()
 					    //,jet.getProperty(PropertyEnum::bCSVscore) //MB: it is not needed when WP is definied
 					    );
   rand_->SetSeed((int)((jet.getP4().Eta()+5)*100000));
@@ -283,11 +285,11 @@ bool ChannelSpecifics::promoteBJet(const HTTParticle &jet){
       histo_eff = btag_eff_b_;
     else if(jetFlavour == BTagEntry::FLAV_C)
       histo_eff = btag_eff_c_;
-    if( jet.getP4().Pt() > histo_eff->GetXaxis()->GetBinLowEdge(histo_eff->GetNbinsX()+1) ){
-      tagging_efficiency = histo_eff->GetBinContent( histo_eff->GetNbinsX(),histo_eff->GetYaxis()->FindBin(std::abs(jet.getP4().Eta())) );
+    if( jet.getP4(aSystEffect).Pt() > histo_eff->GetXaxis()->GetBinLowEdge(histo_eff->GetNbinsX()+1) ){
+      tagging_efficiency = histo_eff->GetBinContent( histo_eff->GetNbinsX(),histo_eff->GetYaxis()->FindBin(std::abs(jet.getP4(aSystEffect).Eta())) );
     }
     else{
-      tagging_efficiency = histo_eff->GetBinContent( histo_eff->GetXaxis()->FindBin(jet.getP4().Pt()),histo_eff->GetYaxis()->FindBin(std::abs(jet.getP4().Eta())) );
+      tagging_efficiency = histo_eff->GetBinContent( histo_eff->GetXaxis()->FindBin(jet.getP4(aSystEffect).Pt()),histo_eff->GetYaxis()->FindBin(std::abs(jet.getP4(aSystEffect).Eta())) );
     }
     //std::cout<<"\tbtag_eff: "<<tagging_efficiency<<std::endl;
     if(tagging_efficiency < 1e-9)//protection

--- a/HTTAnalysis/ChannelSpecifics.cc
+++ b/HTTAnalysis/ChannelSpecifics.cc
@@ -73,6 +73,14 @@ void ChannelSpecifics::defineCategories(){
         pi_rho = new HTTAnalysis::eventCategory("pi_pi", categoryRejester);
         rho_rho = new HTTAnalysis::eventCategory("rho_rho", categoryRejester);
 
+	inclusive = new HTTAnalysis::eventCategory("inclusive", categoryRejester);
+        antiIso_inclusive = new HTTAnalysis::eventCategory("antiIso_inclusive", categoryRejester);
+
+	bjet = new HTTAnalysis::eventCategory("bjet", categoryRejester);
+	nobjet = new HTTAnalysis::eventCategory("nobjet", categoryRejester);
+        antiIso_bjet = new HTTAnalysis::eventCategory("antiIso_bjet", categoryRejester);
+        antiIso_nobjet = new HTTAnalysis::eventCategory("antiIso_nobjet", categoryRejester);
+
 }
 /////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////

--- a/HTTAnalysis/ChannelSpecifics.h
+++ b/HTTAnalysis/ChannelSpecifics.h
@@ -81,6 +81,10 @@ std::vector<const HTTAnalysis::eventCategory*> categoryRejester;
 HTTAnalysis::eventCategory *jet0, *boosted, *vbf;
 HTTAnalysis::eventCategory *antiIso_jet0, *antiIso_boosted, *antiIso_vbf;
 HTTAnalysis::eventCategory *mu_pi, *mu_rho, *pi_pi, *pi_rho, *rho_rho;
+HTTAnalysis::eventCategory *inclusive;
+HTTAnalysis::eventCategory *antiIso_inclusive;
+HTTAnalysis::eventCategory *bjet, *nobjet;
+HTTAnalysis::eventCategory *antiIso_bjet, *antiIso_nobjet;
 
 };
 

--- a/HTTAnalysis/ChannelSpecifics.h
+++ b/HTTAnalysis/ChannelSpecifics.h
@@ -41,7 +41,9 @@ virtual float getLeg2Correction(const HTTAnalysis::sysEffects & aSystEffect) = 0
 
 float getLeptonCorrection(float eta, float pt, float iso, HTTAnalysis::hadronicTauDecayModes tauDecayMode, bool useTauTrigger);
 
-virtual bool promoteBJet(const HTTParticle &jet);
+virtual bool promoteBJet(const HTTParticle &jet,
+			 const HTTAnalysis::sysEffects &aSystEffect=HTTAnalysis::NOMINAL,
+			 std::string correctionType="central");
 
 virtual std::string getDecayModeName() const {
         return decayModeName;
@@ -83,8 +85,8 @@ HTTAnalysis::eventCategory *antiIso_jet0, *antiIso_boosted, *antiIso_vbf;
 HTTAnalysis::eventCategory *mu_pi, *mu_rho, *pi_pi, *pi_rho, *rho_rho;
 HTTAnalysis::eventCategory *inclusive;
 HTTAnalysis::eventCategory *antiIso_inclusive;
-HTTAnalysis::eventCategory *bjet, *nobjet;
-HTTAnalysis::eventCategory *antiIso_bjet, *antiIso_nobjet;
+HTTAnalysis::eventCategory *btag, *nobtag;
+HTTAnalysis::eventCategory *antiIso_btag, *antiIso_nobtag;
 
 };
 

--- a/HTTAnalysis/HTTAnalyzer.cc
+++ b/HTTAnalysis/HTTAnalyzer.cc
@@ -195,8 +195,12 @@ void HTTAnalyzer::fillControlHistos(const std::string & hNameSuffix, float event
         }
         myHistos_->fill1DHistogram("h1DPtMET"+hNameSuffix,aMET.getP4(aSystEffect).Pt(),eventWeight);
 
-	myHistos_->fill1DHistogram("h1DPtLeadingBJet"+hNameSuffix,aBJet1.getP4(aSystEffect).Pt(),eventWeight);
-	myHistos_->fill1DHistogram("h1DEtaLeadingBJet"+hNameSuffix,aBJet1.getP4(aSystEffect).Eta(),eventWeight);
+        myHistos_->fill1DHistogram("h1DStatsNBJets"+hNameSuffix,nBJets,eventWeight);
+        ///Fill b-jets info
+	if(nBJets>0){
+	  myHistos_->fill1DHistogram("h1DPtLeadingBJet"+hNameSuffix,aBJet1.getP4(aSystEffect).Pt(),eventWeight);
+	  myHistos_->fill1DHistogram("h1DEtaLeadingBJet"+hNameSuffix,aBJet1.getP4(aSystEffect).Eta(),eventWeight);
+	}
 
 }
 //////////////////////////////////////////////////////////////////////////////

--- a/HTTAnalysis/HTTAnalyzer.cc
+++ b/HTTAnalysis/HTTAnalyzer.cc
@@ -107,6 +107,17 @@ void HTTAnalyzer::setAnalysisObjects(const EventProxyHTT & myEventProxy){
         aSeparatedJets = getSeparatedJets(myEventProxy, 0.5);
         aJet1 = aSeparatedJets.size() ? aSeparatedJets[0] : HTTParticle();
         aJet2 = aSeparatedJets.size()>1 ? aSeparatedJets[1] : HTTParticle();
+	aBJet1 = HTTParticle();
+	for(auto itJet: aSeparatedJets) {
+          if(std::abs(itJet.getP4().Eta())<2.4 &&
+             itJet.getProperty(PropertyEnum::bCSVscore)>0.8484 && //Medium WP
+             myChannelSpecifics->promoteBJet(itJet)
+	     ){
+	    aBJet1 = itJet;
+	    break;
+	  }
+	}
+           
 }
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
@@ -184,10 +195,9 @@ void HTTAnalyzer::fillControlHistos(const std::string & hNameSuffix, float event
         }
         myHistos_->fill1DHistogram("h1DPtMET"+hNameSuffix,aMET.getP4(aSystEffect).Pt(),eventWeight);
 
-        if(aJet1.getProperty(PropertyEnum::bCSVscore)>0.8) {
-                myHistos_->fill1DHistogram("h1DPtLeadingBJet"+hNameSuffix,aJet1.getP4(aSystEffect).Pt(),eventWeight);
-                myHistos_->fill1DHistogram("h1DEtaLeadingBJet"+hNameSuffix,aJet1.getP4(aSystEffect).Eta(),eventWeight);
-        }
+	myHistos_->fill1DHistogram("h1DPtLeadingBJet"+hNameSuffix,aBJet1.getP4(aSystEffect).Pt(),eventWeight);
+	myHistos_->fill1DHistogram("h1DEtaLeadingBJet"+hNameSuffix,aBJet1.getP4(aSystEffect).Eta(),eventWeight);
+
 }
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/HTTAnalysis/HTTAnalyzer.cc
+++ b/HTTAnalysis/HTTAnalyzer.cc
@@ -195,8 +195,8 @@ void HTTAnalyzer::fillControlHistos(const std::string & hNameSuffix, float event
         }
         myHistos_->fill1DHistogram("h1DPtMET"+hNameSuffix,aMET.getP4(aSystEffect).Pt(),eventWeight);
 
-        myHistos_->fill1DHistogram("h1DStatsNBJets"+hNameSuffix,nBJets,eventWeight);
         ///Fill b-jets info
+        myHistos_->fill1DHistogram("h1DStatsNBJets"+hNameSuffix,nBJets,eventWeight);
 	if(nBJets>0){
 	  myHistos_->fill1DHistogram("h1DPtLeadingBJet"+hNameSuffix,aBJet1.getP4(aSystEffect).Pt(),eventWeight);
 	  myHistos_->fill1DHistogram("h1DEtaLeadingBJet"+hNameSuffix,aBJet1.getP4(aSystEffect).Eta(),eventWeight);

--- a/HTTAnalysis/HTTAnalyzer.h
+++ b/HTTAnalysis/HTTAnalyzer.h
@@ -166,10 +166,11 @@ class HTTAnalyzer: public Analyzer{
 
   HTTParticle aLeg2, aLeg1, aMET;
   HTTParticle aGenLeg1, aGenLeg2;
-  HTTParticle aJet1, aJet2;
+  HTTParticle aJet1, aJet2, aBJet1;
   std::vector<HTTParticle> aSeparatedJets;
   int nJets30;
   int nJetsInGap30;
+  int nBJets;
   std::vector<bool> categoryDecisions;
   unsigned int myNumberOfCategories;
 

--- a/HTTAnalysis/HTTHistograms.cc
+++ b/HTTAnalysis/HTTHistograms.cc
@@ -145,7 +145,7 @@ TH1F *HTTHistograms::getNormalised_NJet_Histogram(const std::string& hName){
         TH1F *hNJetsStats = 0;
 
         if(hName.find("W")!=std::string::npos &&
-           hName.find("DY")==std::string::npos) {
+	   hName.find("DY")==std::string::npos) {
                 sampleName = hName.substr(hName.find("W"));
                 std::string selName = sampleName.substr(sampleName.find("_"));
                 sampleName = sampleName.substr(0,sampleName.size()-selName.size());
@@ -394,7 +394,7 @@ void HTTHistograms::finalizeHistograms(const std::vector<const HTTAnalysis::even
                                                       "antiIso_0jet", "antiIso_boosted", "antiIso_vbf",
                                                       "0jet_QCD", "boosted_QCD", "vbf_QCD",
                                                       "0jet_W", "boosted_W", "vbf_W"
-						      ,"inclusive","bjet","nobjet"
+						      ,"inclusive","btag","nobtag"
 	};
 
         std::vector <unsigned int> mainCategoriesRejester;
@@ -439,6 +439,7 @@ void HTTHistograms::finalizeHistograms(const std::vector<const HTTAnalysis::even
                 plotStack(iCategory, "StatsNJ30");
                 plotStack(iCategory, "PtLeadingJet");
                 plotStack(iCategory, "EtaLeadingJet");
+                plotStack(iCategory, "StatsNBJets");
                 plotStack(iCategory, "CSVBtagLeadingJet");
                 plotStack(iCategory, "PtLeadingBJet");
                 plotStack(iCategory, "EtaLeadingBJet");
@@ -456,7 +457,7 @@ void HTTHistograms::finalizeHistograms(const std::vector<const HTTAnalysis::even
         ///Make systematic effect histos.
         for(unsigned int iSystEffect = (unsigned int)HTTAnalysis::NOMINAL;
             iSystEffect<=(unsigned int)HTTAnalysis::ZmumuDown; ++iSystEffect) {
-                if(iSystEffect==(unsigned int)HTTAnalysis::DUMMY_SYS) continue;
+              if(iSystEffect==(unsigned int)HTTAnalysis::DUMMY_SYS) continue;
                 for(auto iCategory: mainCategoriesRejester) {
                         plotStack(iCategory, "MassSV", iSystEffect);
                         plotStack(iCategory, "MassTrans", iSystEffect);
@@ -483,7 +484,7 @@ void HTTHistograms::plotCPhistograms(unsigned int iCategory){
         plot_HAZ_Histograms("Phi-nVecIP-yTauPos",hNameSuffix+"_GenNoOfflineSel");
         plot_HAZ_Histograms("Phi-nVecIP",hNameSuffix+"_GenNoOfflineSel");
         plot_HAZ_Histograms("Phi-nVectors",hNameSuffix+"_GenNoOfflineSel");
-        std::string categoryName = myCategoryRejester[iCategory]->name();
+	std::string categoryName = myCategoryRejester[iCategory]->name();
         hNameSuffix =  "_"+categoryName;
 
         //plot_HAZ_Histograms("Phi-nVecIP-yTauNeg",hNameSuffix+"_Gen");
@@ -975,8 +976,8 @@ THStack*  HTTHistograms::plotStack(unsigned int iCategory,
         ///events passing particular selection.
         if(!hSoup) {
                 //std::cout<<"No data events for "<<hName<<"Data"<<hNameSuffix
-                //       <<" ("<<categoryName<<")"
-                //     <<std::endl;
+                  //       <<" ("<<categoryName<<")"
+                    //     <<std::endl;
                 return 0;
         }
 
@@ -1522,7 +1523,7 @@ std::pair<float,float> HTTHistograms::getWNormalisation(unsigned int iCategory, 
 
         iCategory = myCategoryRejester[iCategory]->wSF()->id();
         std::string systEffectName = HTTAnalysis::systEffectName(iCategory, iSystEffect, myCategoryRejester);
-        std::string categoryName = myCategoryRejester[iCategory]->name();
+	std::string categoryName = myCategoryRejester[iCategory]->name();
         std::string hNameSuffix =  "_"+categoryName+systEffectName;
 
         std::string varName = "MassTrans";
@@ -1557,11 +1558,11 @@ std::pair<float,float> HTTHistograms::getWNormalisation(unsigned int iCategory, 
         if(iSystEffect==(unsigned int)HTTAnalysis::WSFUp) weight*=(1+WSFUncertainty);
         if(iSystEffect==(unsigned int)HTTAnalysis::WSFDown) weight*=(1-WSFUncertainty);
 
-        outputStream<<"WJets scale with uncertainty: "<<weight<<" WSFUncertainty "<<WSFUncertainty
+	outputStream<<"WJets scale with uncertainty: "<<weight<<" WSFUncertainty "<<WSFUncertainty
         <<" iSystEffect: "<<iSystEffect
-        <<" HTTAnalysis::WSFUp "<<HTTAnalysis::WSFUp
-        <<" HTTAnalysis::WSFDown "<<HTTAnalysis::WSFDown
-        <<endl;
+	<<" HTTAnalysis::WSFUp "<<HTTAnalysis::WSFUp
+	<<" HTTAnalysis::WSFDown "<<HTTAnalysis::WSFDown
+	<<endl;
 
         return std::make_pair(weight, WSFUncertainty);
 }
@@ -1572,7 +1573,7 @@ TH1F *HTTHistograms::get1DHistogram(unsigned int iCategory, std::string varName,
 
         std::string hName = "h1D" + varName;
         std::string systEffectName = HTTAnalysis::systEffectName(iCategory, iSystEffect, myCategoryRejester);
-        std::string categoryName = myCategoryRejester[iCategory]->name();
+	std::string categoryName = myCategoryRejester[iCategory]->name();
         std::string hNameSuffix =  "_"+categoryName+systEffectName;
 
         return get1DHistogram(hName+hNameSuffix);
@@ -1585,7 +1586,7 @@ TH1F *HTTHistograms::getMCSum(unsigned int iCategory, std::string varName,
 
         std::string hName = "h1D" + varName;
         std::string systEffectName = HTTAnalysis::systEffectName(iCategory, iSystEffect, myCategoryRejester);
-        std::string categoryName = myCategoryRejester[iCategory]->name();
+	std::string categoryName = myCategoryRejester[iCategory]->name();
         std::string hNameSuffix =  "_"+categoryName+systEffectName;
 
         TH1F *hWJets = get1D_WJet_Histogram((hName+"WJets"+hNameSuffix));

--- a/HTTAnalysis/HTTHistograms.cc
+++ b/HTTAnalysis/HTTHistograms.cc
@@ -301,7 +301,8 @@ std::string HTTHistograms::getTemplateName(const std::string& name){
         if(name.find("h1DBigMass")!=std::string::npos) templateName = "h1DBigMassTemplate";
         if(name.find("h1DStats")!=std::string::npos) templateName = "h1DStatsTemplate";
         if(name.find("h1DPt")!=std::string::npos) templateName = "h1DPtTemplate";
-        if(name.find("h1DEta")!=std::string::npos) templateName = "h1DEtaTemplate";
+        if(name.find("h1DEta")!=std::string::npos && name.find("Jet")==std::string::npos) templateName = "h1DEtaTemplate";
+        if(name.find("h1DEta")!=std::string::npos && name.find("Jet")!=std::string::npos) templateName = "h1DJetEtaTemplate";
         if(name.find("h1DDeltaEta")!=std::string::npos) templateName = "h1DDeltaEtaTemplate";
         if(name.find("h1DIso")!=std::string::npos) templateName = "h1DIsoTemplate";
         if(name.find("h1DPhi")!=std::string::npos) templateName = "h1DPhiTemplate";
@@ -346,6 +347,7 @@ void HTTHistograms::defineHistograms(){
                 add1DHistogram("h1DBigMassTemplate",";mass [GeV/c^{2}]; Events",25,0,1500,file_);
                 add1DHistogram("h1DPtTemplate",";p_{T}; Events",20,0,100,file_);
                 add1DHistogram("h1DEtaTemplate",";#eta; Events",24,-2.4,2.4,file_);
+                add1DHistogram("h1DJetEtaTemplate",";#eta; Events",50,-5,5,file_);
                 add1DHistogram("h1DDeltaEtaTemplate",";#Delta#eta; Events",50,0,10,file_);
                 add1DHistogram("h1DPhiTemplate",";#phi; Events",6,0,2*M_PI,file_);
                 add1DHistogram("h1DCosPhiTemplate",";cos(#phi); Events",10,-1.0,1.0,file_);
@@ -391,7 +393,9 @@ void HTTHistograms::finalizeHistograms(const std::vector<const HTTAnalysis::even
         std::vector<std::string> mainCategoryNames = {"0jet","boosted", "vbf",
                                                       "antiIso_0jet", "antiIso_boosted", "antiIso_vbf",
                                                       "0jet_QCD", "boosted_QCD", "vbf_QCD",
-                                                      "0jet_W", "boosted_W", "vbf_W"};
+                                                      "0jet_W", "boosted_W", "vbf_W"
+						      ,"inclusive","bjet","nobjet"
+	};
 
         std::vector <unsigned int> mainCategoriesRejester;
         for(unsigned int iCategory=0; iCategory<myCategoryRejester.size(); ++iCategory) {

--- a/HTTAnalysis/HTTSynchNTuple.cc
+++ b/HTTAnalysis/HTTSynchNTuple.cc
@@ -187,6 +187,8 @@ void HTTSynchNTuple::clearTTreeVariables(){
   //MET
   met = -999;
   metphi = -999;
+  pfmet = -999;
+  pfmetphi = -999;
   puppimet = -999;
   puppimetphi = -999;
   mvamet = -999;
@@ -354,6 +356,8 @@ void HTTSynchNTuple::addBranch(TTree *tree){
   //MET
   tree->Branch("met",&met);
   tree->Branch("metphi",&metphi);
+  tree->Branch("pfmet",&pfmet);
+  tree->Branch("pfmetphi",&pfmetphi);
   tree->Branch("puppimet",&puppimet);
   tree->Branch("puppimetphi",&puppimetphi);
   tree->Branch("mvamet",&mvamet);
@@ -762,14 +766,17 @@ void HTTSynchNTuple::fillPair(const HTTEvent &event, HTTPair &pair){
   TLorentzVector leg2P4 = pair.getLeg2().getP4();
 
   //MET
-  TLorentzVector metP4(event.getMET().X(), event.getMET().Y(), 0, event.getMET().Mod());
-  met = event.getMET().Mod();
-  metphi = event.getMET().Phi_mpi_pi(event.getMET().Phi());
-  pfmt_1 = TMath::Sqrt(2.*leg1P4.Pt()*metP4.Pt()*(1.-TMath::Cos(leg1P4.Phi()-metP4.Phi())));
-  pfmt_2 = TMath::Sqrt(2.*leg2P4.Pt()*metP4.Pt()*(1.-TMath::Cos(leg2P4.Phi()-metP4.Phi())));
+  TLorentzVector pfmetP4(event.getMET().X(), event.getMET().Y(), 0, event.getMET().Mod());
+  pfmet = event.getMET().Mod();
+  pfmetphi = event.getMET().Phi_mpi_pi(event.getMET().Phi());
+  pfmt_1 = TMath::Sqrt(2.*leg1P4.Pt()*pfmetP4.Pt()*(1.-TMath::Cos(leg1P4.Phi()-pfmetP4.Phi())));
+  pfmt_2 = TMath::Sqrt(2.*leg2P4.Pt()*pfmetP4.Pt()*(1.-TMath::Cos(leg2P4.Phi()-pfmetP4.Phi())));
+  //Pair met: by default called MVAMET which can be wrong...
   TLorentzVector mvametP4(pair.getMET().X(), pair.getMET().Y(), 0, pair.getMET().Mod());
   mvamet = pair.getMET().Mod();
   mvametphi = pair.getMET().Phi_mpi_pi(pair.getMET().Phi());
+  met = mvamet;
+  metphi = mvametphi;
   mt_1 = TMath::Sqrt(2.*leg1P4.Pt()*mvametP4.Pt()*(1.-TMath::Cos(leg1P4.Phi()-mvametP4.Phi())));
   mt_2 = TMath::Sqrt(2.*leg2P4.Pt()*mvametP4.Pt()*(1.-TMath::Cos(leg2P4.Phi()-mvametP4.Phi())));
   /*
@@ -797,6 +804,10 @@ void HTTSynchNTuple::fillPair(const HTTEvent &event, HTTPair &pair){
   mvacov01 = pair.getMETMatrix().at(1);
   mvacov10 = pair.getMETMatrix().at(2);
   mvacov11 = pair.getMETMatrix().at(3);
+  metcov00 = mvacov00;
+  metcov01 = mvacov01;
+  metcov10 = mvacov10;
+  metcov11 = mvacov11;
 
 }
 //////////////////////////////////////////////////////////////////////////////

--- a/HTTAnalysis/HTTSynchNTuple.h
+++ b/HTTAnalysis/HTTSynchNTuple.h
@@ -219,6 +219,8 @@ class HTTSynchNTuple: public Analyzer{
   //MET
   Float_t met;
   Float_t metphi;
+  Float_t pfmet;
+  Float_t pfmetphi;
   Float_t puppimet;
   Float_t puppimetphi;
   Float_t mvamet;

--- a/HTTAnalysis/MuTauSpecifics.cc
+++ b/HTTAnalysis/MuTauSpecifics.cc
@@ -101,6 +101,14 @@ void MuTauSpecifics::testAllCategories(const HTTAnalysis::sysEffects & aSystEffe
                         }
                 }
         }
+	myAnalyzer->nBJets = 0;
+	for(auto itJet: myAnalyzer->aSeparatedJets) {
+	  if(std::abs(itJet.getP4(aSystEffect).Eta())<2.4 &&
+	     itJet.getP4(aSystEffect).Pt()>20 && //MB needed??
+	     itJet.getProperty(PropertyEnum::bCSVscore)>0.8484 && //Medium WP
+	     promoteBJet(itJet)
+	     ) 	++myAnalyzer->nBJets;
+        }
 
         float jetsMass = (myAnalyzer->aJet1.getP4(aSystEffect)+myAnalyzer->aJet2.getP4(aSystEffect)).M();
         float higgsPt =  (myAnalyzer->aLeg1.getP4(aSystEffect) + myAnalyzer->aLeg2.getP4(aSystEffect) + myAnalyzer->aMET.getP4(aSystEffect)).Pt();
@@ -140,16 +148,26 @@ void MuTauSpecifics::testAllCategories(const HTTAnalysis::sysEffects & aSystEffe
 
         bool ss = myAnalyzer->aLeg2.getCharge()*myAnalyzer->aLeg1.getCharge() == 1;
         bool os = myAnalyzer->aLeg2.getCharge()*myAnalyzer->aLeg1.getCharge() == -1;
+	bool bjet = myAnalyzer->nBJets>=1 && myAnalyzer->nJets30<=1;
+	bool nobjet = myAnalyzer->nBJets==0;
 
         //Main categories
         myAnalyzer->categoryDecisions[ChannelSpecifics::jet0->id()] = os && muonIso && mtSelection && jet0;
         myAnalyzer->categoryDecisions[ChannelSpecifics::boosted->id()] = os && muonIso && mtSelection && boosted;
         myAnalyzer->categoryDecisions[ChannelSpecifics::vbf->id()] = os && muonIso && mtSelection && vbf;
-        myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_jet0->id()] = os && muonAntiIso && jet0;
-        myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_boosted->id()] = os && muonAntiIso && boosted;
-        myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_vbf->id()] = os && muonAntiIso && vbf;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_jet0->id()] = os && muonAntiIso && mtSelection && jet0;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_boosted->id()] = os && muonAntiIso && mtSelection && boosted;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_vbf->id()] = os && muonAntiIso && mtSelection && vbf;
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_pi->id()] = os && muonIso && mtSelection && cpPi;
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_rho->id()] = os && muonIso && mtSelection && cpRho;
+
+	 myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->id()] = os && muonIso && mtSelection;
+	 //myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_inclusive->id()] = os && muonAntiIso && mtSelection;
+	 myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->id()] = os && muonIso && mtSelection && bjet;
+	 //myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_bjet->id()] = os && muonAntiIso && mtSelection && bjet;
+	 myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->id()] = os && muonIso && mtSelection && nobjet;
+	 //myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_nobjet->id()] = os && muonAntiIso && mtSelection && nobjet;
+	 
 
         //W control region
         myAnalyzer->categoryDecisions[ChannelSpecifics::jet0->wSF()->id()] = os && muonIso && wSelection && jet0;
@@ -160,6 +178,9 @@ void MuTauSpecifics::testAllCategories(const HTTAnalysis::sysEffects & aSystEffe
         myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_vbf->wSF()->id()] = os && muonAntiIso && wSelection && vbf;
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_pi->wSF()->id()] = os && muonIso && wSelection && cpPi;
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_rho->wSF()->id()] = os && muonIso && wSelection && cpRho;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->wSF()->id()] = os && muonIso && wSelection;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->wSF()->id()] = os && muonIso && wSelection && bjet;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->wSF()->id()] = os && muonIso && wSelection && nobjet;
 
         ///QCD region in W SF control region
         myAnalyzer->categoryDecisions[ChannelSpecifics::jet0->wSF()->qcdEstimate()->id()] = ss && muonIso && wSelection && jet0;
@@ -170,6 +191,9 @@ void MuTauSpecifics::testAllCategories(const HTTAnalysis::sysEffects & aSystEffe
         myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_vbf->wSF()->qcdEstimate()->id()] = ss && muonAntiIso && wSelection && vbf;
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_pi->wSF()->qcdEstimate()->id()] = ss && muonIso && wSelection && cpPi;
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_rho->wSF()->qcdEstimate()->id()] = ss && muonIso && wSelection && cpRho;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->wSF()->qcdEstimate()->id()] = ss && muonIso && wSelection;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->wSF()->qcdEstimate()->id()] = ss && muonIso && wSelection && bjet;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->wSF()->qcdEstimate()->id()] = ss && muonIso && wSelection && nobjet;
 
         ///QCD region
         myAnalyzer->categoryDecisions[ChannelSpecifics::jet0->qcdEstimate()->id()] = ss && muonIso && mtSelection && jet0;
@@ -180,6 +204,9 @@ void MuTauSpecifics::testAllCategories(const HTTAnalysis::sysEffects & aSystEffe
         myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_vbf->qcdEstimate()->id()] = ss && muonAntiIso && vbf;
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_pi->qcdEstimate()->id()] = ss && muonIso && mtSelection && cpPi;
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_rho->qcdEstimate()->id()] = ss && muonIso && mtSelection && cpRho;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->qcdEstimate()->id()] = ss && muonIso && mtSelection;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->qcdEstimate()->id()] = ss && muonIso && mtSelection && bjet;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->qcdEstimate()->id()] = ss && muonIso && mtSelection && nobjet;
 
         ///W SF region in QCD region
         myAnalyzer->categoryDecisions[ChannelSpecifics::jet0->qcdEstimate()->wSF()->id()] = ss && muonIso && wSelection && jet0;
@@ -190,6 +217,9 @@ void MuTauSpecifics::testAllCategories(const HTTAnalysis::sysEffects & aSystEffe
         myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_vbf->qcdEstimate()->wSF()->id()] = ss && muonAntiIso && vbf;
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_pi->qcdEstimate()->wSF()->id()] = ss && muonIso && wSelection && cpPi;
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_rho->qcdEstimate()->wSF()->id()] = ss && muonIso && wSelection && cpRho;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->qcdEstimate()->wSF()->id()] = ss && muonIso && wSelection;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->qcdEstimate()->wSF()->id()] = ss && muonIso && wSelection && bjet;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->qcdEstimate()->wSF()->id()] = ss && muonIso && wSelection && nobjet;
 }
 /////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////

--- a/HTTAnalysis/MuTauSpecifics.cc
+++ b/HTTAnalysis/MuTauSpecifics.cc
@@ -106,7 +106,7 @@ void MuTauSpecifics::testAllCategories(const HTTAnalysis::sysEffects & aSystEffe
 	  if(std::abs(itJet.getP4(aSystEffect).Eta())<2.4 &&
 	     itJet.getP4(aSystEffect).Pt()>20 && //MB needed??
 	     itJet.getProperty(PropertyEnum::bCSVscore)>0.8484 && //Medium WP
-	     promoteBJet(itJet)
+	     promoteBJet(itJet,aSystEffect,"central")//FIXME: need to variate central to up/down
 	     ) 	++myAnalyzer->nBJets;
         }
 
@@ -148,8 +148,9 @@ void MuTauSpecifics::testAllCategories(const HTTAnalysis::sysEffects & aSystEffe
 
         bool ss = myAnalyzer->aLeg2.getCharge()*myAnalyzer->aLeg1.getCharge() == 1;
         bool os = myAnalyzer->aLeg2.getCharge()*myAnalyzer->aLeg1.getCharge() == -1;
-	bool bjet = myAnalyzer->nBJets>=1 && myAnalyzer->nJets30<=1;
-	bool nobjet = myAnalyzer->nBJets==0;
+	//b-tag categories
+	bool btag = myAnalyzer->nBJets>=1 && myAnalyzer->nJets30<=1;
+	bool nobtag = myAnalyzer->nBJets==0;
 
         //Main categories
         myAnalyzer->categoryDecisions[ChannelSpecifics::jet0->id()] = os && muonIso && mtSelection && jet0;
@@ -163,10 +164,10 @@ void MuTauSpecifics::testAllCategories(const HTTAnalysis::sysEffects & aSystEffe
 
 	 myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->id()] = os && muonIso && mtSelection;
 	 //myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_inclusive->id()] = os && muonAntiIso && mtSelection;
-	 myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->id()] = os && muonIso && mtSelection && bjet;
-	 //myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_bjet->id()] = os && muonAntiIso && mtSelection && bjet;
-	 myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->id()] = os && muonIso && mtSelection && nobjet;
-	 //myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_nobjet->id()] = os && muonAntiIso && mtSelection && nobjet;
+	 myAnalyzer->categoryDecisions[ChannelSpecifics::btag->id()] = os && muonIso && mtSelection && btag;
+	 //myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_btag->id()] = os && muonAntiIso && mtSelection && btag;
+	 myAnalyzer->categoryDecisions[ChannelSpecifics::nobtag->id()] = os && muonIso && mtSelection && nobtag;
+	 //myAnalyzer->categoryDecisions[ChannelSpecifics::antiIso_nobtag->id()] = os && muonAntiIso && mtSelection && nobtag;
 	 
 
         //W control region
@@ -179,8 +180,8 @@ void MuTauSpecifics::testAllCategories(const HTTAnalysis::sysEffects & aSystEffe
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_pi->wSF()->id()] = os && muonIso && wSelection && cpPi;
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_rho->wSF()->id()] = os && muonIso && wSelection && cpRho;
         myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->wSF()->id()] = os && muonIso && wSelection;
-        myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->wSF()->id()] = os && muonIso && wSelection && bjet;
-        myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->wSF()->id()] = os && muonIso && wSelection && nobjet;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::btag->wSF()->id()] = os && muonIso && wSelection && btag;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::nobtag->wSF()->id()] = os && muonIso && wSelection && nobtag;
 
         ///QCD region in W SF control region
         myAnalyzer->categoryDecisions[ChannelSpecifics::jet0->wSF()->qcdEstimate()->id()] = ss && muonIso && wSelection && jet0;
@@ -192,8 +193,8 @@ void MuTauSpecifics::testAllCategories(const HTTAnalysis::sysEffects & aSystEffe
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_pi->wSF()->qcdEstimate()->id()] = ss && muonIso && wSelection && cpPi;
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_rho->wSF()->qcdEstimate()->id()] = ss && muonIso && wSelection && cpRho;
         myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->wSF()->qcdEstimate()->id()] = ss && muonIso && wSelection;
-        myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->wSF()->qcdEstimate()->id()] = ss && muonIso && wSelection && bjet;
-        myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->wSF()->qcdEstimate()->id()] = ss && muonIso && wSelection && nobjet;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::btag->wSF()->qcdEstimate()->id()] = ss && muonIso && wSelection && btag;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::nobtag->wSF()->qcdEstimate()->id()] = ss && muonIso && wSelection && nobtag;
 
         ///QCD region
         myAnalyzer->categoryDecisions[ChannelSpecifics::jet0->qcdEstimate()->id()] = ss && muonIso && mtSelection && jet0;
@@ -205,8 +206,8 @@ void MuTauSpecifics::testAllCategories(const HTTAnalysis::sysEffects & aSystEffe
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_pi->qcdEstimate()->id()] = ss && muonIso && mtSelection && cpPi;
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_rho->qcdEstimate()->id()] = ss && muonIso && mtSelection && cpRho;
         myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->qcdEstimate()->id()] = ss && muonIso && mtSelection;
-        myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->qcdEstimate()->id()] = ss && muonIso && mtSelection && bjet;
-        myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->qcdEstimate()->id()] = ss && muonIso && mtSelection && nobjet;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::btag->qcdEstimate()->id()] = ss && muonIso && mtSelection && btag;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::nobtag->qcdEstimate()->id()] = ss && muonIso && mtSelection && nobtag;
 
         ///W SF region in QCD region
         myAnalyzer->categoryDecisions[ChannelSpecifics::jet0->qcdEstimate()->wSF()->id()] = ss && muonIso && wSelection && jet0;
@@ -218,8 +219,8 @@ void MuTauSpecifics::testAllCategories(const HTTAnalysis::sysEffects & aSystEffe
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_pi->qcdEstimate()->wSF()->id()] = ss && muonIso && wSelection && cpPi;
         myAnalyzer->categoryDecisions[ChannelSpecifics::mu_rho->qcdEstimate()->wSF()->id()] = ss && muonIso && wSelection && cpRho;
         myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->qcdEstimate()->wSF()->id()] = ss && muonIso && wSelection;
-        myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->qcdEstimate()->wSF()->id()] = ss && muonIso && wSelection && bjet;
-        myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->qcdEstimate()->wSF()->id()] = ss && muonIso && wSelection && nobjet;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::btag->qcdEstimate()->wSF()->id()] = ss && muonIso && wSelection && btag;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::nobtag->qcdEstimate()->wSF()->id()] = ss && muonIso && wSelection && nobtag;
 }
 /////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////

--- a/HTTAnalysis/TauTauSpecifics.cc
+++ b/HTTAnalysis/TauTauSpecifics.cc
@@ -125,6 +125,14 @@ void TauTauSpecifics::testAllCategories(const HTTAnalysis::sysEffects & aSystEff
                         }
                 }
         }
+	myAnalyzer->nBJets = 0;
+	for(auto itJet: myAnalyzer->aSeparatedJets) {
+	  if(std::abs(itJet.getP4(aSystEffect).Eta())<2.4 &&
+	     itJet.getP4(aSystEffect).Pt()>20 && //MB needed??
+	     itJet.getProperty(PropertyEnum::bCSVscore)>0.8484 && //Medium WP
+	     promoteBJet(itJet)
+	     ) 	++myAnalyzer->nBJets;
+        }
 
         float jetsMass = (myAnalyzer->aJet1.getP4(aSystEffect)+myAnalyzer->aJet2.getP4(aSystEffect)).M();
         float jetsEta = std::abs(myAnalyzer->aJet1.getP4().Eta() - myAnalyzer->aJet2.getP4().Eta());
@@ -157,25 +165,40 @@ void TauTauSpecifics::testAllCategories(const HTTAnalysis::sysEffects & aSystEff
         bool piRho = (isPi1 && isRho2) || (isPi2 && isRho1);
         bool rhoRho = isRho1 && isRho2;
 
+	bool bjet = myAnalyzer->nBJets>=1 && myAnalyzer->nJets30<=1;
+	bool nobjet = myAnalyzer->nBJets==0;
+
          //Main categories
         myAnalyzer->categoryDecisions[ChannelSpecifics::jet0->id()] = os && fullIso && jet0;
         myAnalyzer->categoryDecisions[ChannelSpecifics::boosted->id()] = os && fullIso && boosted;
         myAnalyzer->categoryDecisions[ChannelSpecifics::vbf->id()] = os && fullIso && vbf_2d;
+	myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->id()] = os && fullIso;
+	myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->id()] = os && fullIso && bjet;
+	myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->id()] = os && fullIso && nobjet;
 
         ///QCD region
         myAnalyzer->categoryDecisions[ChannelSpecifics::jet0->qcdEstimate()->id()] = os && antiIso && jet0;
         myAnalyzer->categoryDecisions[ChannelSpecifics::boosted->qcdEstimate()->id()] = os && antiIso &&  boosted;
         myAnalyzer->categoryDecisions[ChannelSpecifics::vbf->qcdEstimate()->id()] = os && antiIso && vbf_2d;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->qcdEstimate()->id()] = os && antiIso;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->qcdEstimate()->id()] = os && antiIso && bjet;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->qcdEstimate()->id()] = os && antiIso && nobjet;
 
         ///QCD SF denominator
         myAnalyzer->categoryDecisions[ChannelSpecifics::jet0->qcdSFDenominator()->id()] = ss && antiIso && jet0;
         myAnalyzer->categoryDecisions[ChannelSpecifics::boosted->qcdSFDenominator()->id()] = ss && antiIso &&  boosted;
         myAnalyzer->categoryDecisions[ChannelSpecifics::vbf->qcdSFDenominator()->id()] = ss && antiIso && vbf_2d;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->qcdSFDenominator()->id()] = ss && antiIso;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->qcdSFDenominator()->id()] = ss && antiIso && bjet;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->qcdSFDenominator()->id()] = ss && antiIso && nobjet;
 
         ///QCD SF numerator
         myAnalyzer->categoryDecisions[ChannelSpecifics::jet0->qcdSFNumerator()->id()] = ss && fullIso && jet0;
         myAnalyzer->categoryDecisions[ChannelSpecifics::boosted->qcdSFNumerator()->id()] = ss && fullIso &&  boosted;
         myAnalyzer->categoryDecisions[ChannelSpecifics::vbf->qcdSFNumerator()->id()] = ss && fullIso && vbf_2d;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->qcdSFNumerator()->id()] = ss && fullIso;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->qcdSFNumerator()->id()] = ss && fullIso && bjet;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->qcdSFNumerator()->id()] = ss && fullIso && nobjet;
 /*
         myAnalyzer->categoryDecisions[(int)HTTAnalysis::pi_pi] = os && fullIso && piPi;
         myAnalyzer->categoryDecisions[(int)HTTAnalysis::pi_rho] = os && fullIso && piRho;

--- a/HTTAnalysis/TauTauSpecifics.cc
+++ b/HTTAnalysis/TauTauSpecifics.cc
@@ -130,7 +130,7 @@ void TauTauSpecifics::testAllCategories(const HTTAnalysis::sysEffects & aSystEff
 	  if(std::abs(itJet.getP4(aSystEffect).Eta())<2.4 &&
 	     itJet.getP4(aSystEffect).Pt()>20 && //MB needed??
 	     itJet.getProperty(PropertyEnum::bCSVscore)>0.8484 && //Medium WP
-	     promoteBJet(itJet)
+	     promoteBJet(itJet,aSystEffect,"central")//FIXME: need to variate central to up/down
 	     ) 	++myAnalyzer->nBJets;
         }
 
@@ -165,40 +165,40 @@ void TauTauSpecifics::testAllCategories(const HTTAnalysis::sysEffects & aSystEff
         bool piRho = (isPi1 && isRho2) || (isPi2 && isRho1);
         bool rhoRho = isRho1 && isRho2;
 
-	bool bjet = myAnalyzer->nBJets>=1 && myAnalyzer->nJets30<=1;
-	bool nobjet = myAnalyzer->nBJets==0;
+	bool btag = myAnalyzer->nBJets>=1 && myAnalyzer->nJets30<=1;
+	bool nobtag = myAnalyzer->nBJets==0;
 
          //Main categories
         myAnalyzer->categoryDecisions[ChannelSpecifics::jet0->id()] = os && fullIso && jet0;
         myAnalyzer->categoryDecisions[ChannelSpecifics::boosted->id()] = os && fullIso && boosted;
         myAnalyzer->categoryDecisions[ChannelSpecifics::vbf->id()] = os && fullIso && vbf_2d;
 	myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->id()] = os && fullIso;
-	myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->id()] = os && fullIso && bjet;
-	myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->id()] = os && fullIso && nobjet;
+	myAnalyzer->categoryDecisions[ChannelSpecifics::btag->id()] = os && fullIso && btag;
+	myAnalyzer->categoryDecisions[ChannelSpecifics::nobtag->id()] = os && fullIso && nobtag;
 
         ///QCD region
         myAnalyzer->categoryDecisions[ChannelSpecifics::jet0->qcdEstimate()->id()] = os && antiIso && jet0;
         myAnalyzer->categoryDecisions[ChannelSpecifics::boosted->qcdEstimate()->id()] = os && antiIso &&  boosted;
         myAnalyzer->categoryDecisions[ChannelSpecifics::vbf->qcdEstimate()->id()] = os && antiIso && vbf_2d;
         myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->qcdEstimate()->id()] = os && antiIso;
-        myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->qcdEstimate()->id()] = os && antiIso && bjet;
-        myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->qcdEstimate()->id()] = os && antiIso && nobjet;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::btag->qcdEstimate()->id()] = os && antiIso && btag;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::nobtag->qcdEstimate()->id()] = os && antiIso && nobtag;
 
         ///QCD SF denominator
         myAnalyzer->categoryDecisions[ChannelSpecifics::jet0->qcdSFDenominator()->id()] = ss && antiIso && jet0;
         myAnalyzer->categoryDecisions[ChannelSpecifics::boosted->qcdSFDenominator()->id()] = ss && antiIso &&  boosted;
         myAnalyzer->categoryDecisions[ChannelSpecifics::vbf->qcdSFDenominator()->id()] = ss && antiIso && vbf_2d;
         myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->qcdSFDenominator()->id()] = ss && antiIso;
-        myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->qcdSFDenominator()->id()] = ss && antiIso && bjet;
-        myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->qcdSFDenominator()->id()] = ss && antiIso && nobjet;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::btag->qcdSFDenominator()->id()] = ss && antiIso && btag;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::nobtag->qcdSFDenominator()->id()] = ss && antiIso && nobtag;
 
         ///QCD SF numerator
         myAnalyzer->categoryDecisions[ChannelSpecifics::jet0->qcdSFNumerator()->id()] = ss && fullIso && jet0;
         myAnalyzer->categoryDecisions[ChannelSpecifics::boosted->qcdSFNumerator()->id()] = ss && fullIso &&  boosted;
         myAnalyzer->categoryDecisions[ChannelSpecifics::vbf->qcdSFNumerator()->id()] = ss && fullIso && vbf_2d;
         myAnalyzer->categoryDecisions[ChannelSpecifics::inclusive->qcdSFNumerator()->id()] = ss && fullIso;
-        myAnalyzer->categoryDecisions[ChannelSpecifics::bjet->qcdSFNumerator()->id()] = ss && fullIso && bjet;
-        myAnalyzer->categoryDecisions[ChannelSpecifics::nobjet->qcdSFNumerator()->id()] = ss && fullIso && nobjet;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::btag->qcdSFNumerator()->id()] = ss && fullIso && btag;
+        myAnalyzer->categoryDecisions[ChannelSpecifics::nobtag->qcdSFNumerator()->id()] = ss && fullIso && nobtag;
 /*
         myAnalyzer->categoryDecisions[(int)HTTAnalysis::pi_pi] = os && fullIso && piPi;
         myAnalyzer->categoryDecisions[(int)HTTAnalysis::pi_rho] = os && fullIso && piRho;


### PR DESCRIPTION
HTTAnalysis
* Tak jak w tytule: dodane kategorie dla MSSM (btag/nobtag) i inclusive
* Modyfikacja funkcji promoujacej b-jety aby zalezala systematyki jetow oraz mogla zwrocic korekcje up/down (do dodania do systematyki)
* Troche kosmetyki, np. inny zakres eta dla histogramow dzetowych

HTTSynchNtuple
* Troche kosmetyki zwiazanej z MET: zmienne zwiazane z METem z pary zapisywane konsystentnie jako met* (oraz mvamet* jak dotad) a zmienne z pfmetem (bez korekcji) jako pfmet* => poprawa zgodnosci dla met, metcov 

@akalinow Mysle ze przed commitem zsynchronizowalem z ostatnimi zmianami w master zwiazanymi z poprawkami systematyki sprzed swiat, ale prosze sprawdz to dokladnie przed mergowaniem.
