### PR TITLE
SFs for mu-tau x-trigger (SynchNTuple producer)

### DIFF
--- a/HTTAnalysis/HTTSynchNTuple.h
+++ b/HTTAnalysis/HTTSynchNTuple.h
@@ -100,10 +100,11 @@ class HTTSynchNTuple: public Analyzer{
 
   ///Histograms with lepton corrections
   TH2F *h2DMuonIdCorrections;
-  TH3F *h3DMuonIsoCorrections, *h3DMuonTrgCorrections;
+  TH3F *h3DMuonIsoCorrections, *h3DMuonTrgCorrections, *h3DMuonXTrgCorrections;
   TH1F *h1DMuonTrkCorrections;
   TH3F *h3DTauCorrections;
   TH2F *h2DTauTrgGenuineCorrections, *h2DTauTrgFakeCorrections;
+  TH2F *h2DTauXTrgGenuineCorrections, *h2DTauXTrgFakeCorrections;
 
   //For PU
   TFile *puDataFile_, *puMCFile_;


### PR DESCRIPTION
Jak w tytule: dodałem wagi dla trygera mu+tau do producera HTTSynchNTuple. 
Do zrobienia:
* Przetestować z plikiem synchronizacyjmym VBF H125
* Dodać plik z korekcjami SM (htt_scalefactors_sm_moriond_v2.root) do repozytorium na WWW Artura i zrobić czytanie CACHEREAD. Plik do znalezienia tu: https://github.com/CMS-HTT/CorrectionsWorkspace
* Przekopiować korekcje do HTTAnalysis (ChannelSpecifics.cc) i przetestować (zgodność datacardów)

@apyskir: FYI

